### PR TITLE
Test runner mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,15 @@ You can also pass the core and rom like this:
 emutest -L path/to/core_libretro.so -r path/to/rom.bin -t path/to/test.lua
 ```
 
+These if passed go into the Lua variables:
+
+* filename = path to test file
+* rompath = path to ROM
+* corepath = path to core library
+
+If you pass the `-T` flag, the Lua script must call os.exit(status) or
+emutest will itself return an error.
+
 This is an example test file:
 
 ```

--- a/debugging/debugging.go
+++ b/debugging/debugging.go
@@ -1,0 +1,21 @@
+// Package debugging has introspection functions for testing
+package debugging
+
+import (
+	"C"
+
+	"github.com/kivutar/emutest/state"
+	"github.com/libretro/ludo/libretro"
+)
+
+// GetRAM prints the content of the SRAM
+func GetSystemRAM() []byte {
+	len := state.Core.GetMemorySize(libretro.MemorySystemRAM)
+	ptr := state.Core.GetMemoryData(libretro.MemorySystemRAM)
+	if ptr == nil || len == 0 {
+		return []byte{}
+	}
+
+	// convert the C array to a go slice
+	return C.GoBytes(ptr, C.int(len))
+}

--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,4 @@ require (
 	github.com/pelletier/go-toml v1.9.1
 )
 
-go 1.18
+go 1.21

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 
 	"github.com/kivutar/emutest/core"
+	"github.com/kivutar/emutest/debugging"
 	"github.com/kivutar/emutest/input"
 	"github.com/kivutar/emutest/options"
 	"github.com/kivutar/emutest/savefiles"
@@ -40,6 +41,17 @@ func registerFuncs(l *lua.State) {
 	l.Register("run", func(l *lua.State) int {
 		run()
 		return 0
+	})
+	l.Register("get_ram", func(l *lua.State) int {
+		sram := debugging.GetSystemRAM()
+		l.PushString(string(sram[:]))
+		return 1
+	})
+	l.Register("get_ram_byte", func(l *lua.State) int {
+		offset := lua.CheckInteger(l, 1)
+		sram := debugging.GetSystemRAM()
+		l.PushInteger(int(sram[offset]))
+		return 1
 	})
 	l.Register("get_sram", func(l *lua.State) int {
 		sram := savefiles.GetSRAM()

--- a/savefiles/savefiles.go
+++ b/savefiles/savefiles.go
@@ -11,6 +11,7 @@ import (
 	"github.com/libretro/ludo/libretro"
 )
 
+
 // GetSRAM prints the content of the SRAM
 func GetSRAM() []byte {
 	len := state.Core.GetMemorySize(libretro.MemorySaveRAM)


### PR DESCRIPTION
These are changes to support the LLVM-MOS-SDK project.

It introduces a new -T flag for test runner mode. This mode requires the Lua program call os.exit() with a test result, otherwise emutest will return a failure code.

It also adds get_ram() and get_ram_byte(offset) functions to inspect memory.